### PR TITLE
Build scripts updates (for third party libraries and programs)

### DIFF
--- a/scripts/functions_build
+++ b/scripts/functions_build
@@ -749,127 +749,184 @@ UsageBuild()
 compileDateTime() {
   local root_dir src_dir cmake_flags
   local bld_dir lib_dir inc_dir inst_dir
-  local i
-  local err=0
-
-  ### Get the location of the third party directory
-  if [ -d "${1}" ]; then
-    root_dir="${1}"
-  else
-    root_dir="${APP_DIR:+${APP_DIR}/}thirdparty_open"
-  fi
-
-  ### Get the location of the install directory
-  inst_dir="${APP_DIR:+${APP_DIR}/}THIRDPARTY_INSTALL"
+  local i tmp_inc tmp_lib
+  local err tpDateTimeRequested
 
 
-  ##########
-  ### Try to get all the required directories to compile the application 
-  ##########
-  src_dir="$( find ${root_dir} -maxdepth 1 -type d -iname "*DATETIME*" | head -n 1 )"
-  if [ -z "${src_dir}" ] || [ ! -d "${src_dir}" ]; then
-    procError "the source directory for the DateTime library is not a valid directory:" \
-              "  srcDIR = ${src_dir:-NOTFOUND}" \
-              "searched in rootDIR = ${root_dir:-NOTFOUND}"
-  fi
+  err=0
+  tpDateTimeRequested=0
 
-  bld_dir=${src_dir}/build
-  lib_dir=${src_dir}/lib
-  inc_dir=${src_dir}/include
 
-  ### Remove/Clean the previously compiled programs and libraries
-  for i in ${bld_dir} ${lib_dir} ${inc_dir}
+  # First check if the user explicitly requested to build DateTime
+  # from the thirdparty_open directory.
+  for iPart in ${THIRDPARTY}
   do
-    if [ -d "${i}" ]; then
-      rm -rf ${i}
-      err=$?
-    fi
+    case "$( toUPPER ${iPart} )" in
+      DATETIME)
+        tpDateTimeRequested=1
+        break
+        ;;
+      *)
+        ;; #Do Nothing
+    esac
   done
-  ##########
 
 
-  ### Set the compilation flags for cmake
-  cmake_flags="-DCMAKE_BUILD_TYPE=Release"
-  [ -n "${VERBOSE:+1}" ] && cmake_flags+=" -DCMAKE_VERBOSE_MAKEFILE=TRUE"
-
-  cmake_flags+=" -DCMAKE_Fortran_COMPILER=${F90:-${FC}}"
-  [ -n "${FFLAGS:+1}" ] && cmake_flags+=" -DCMAKE_Fortran_FLAGS=${FFLAGS}"
-
-
-  ##########
-  ### Run cmake to configure the application
-  ##########
-  eval "cmake -S ${src_dir} -B ${bld_dir} ${cmake_flags}"
-  err=$?
-
-  if [ ${err:-0} -ne 0 ]; then
-    procError "the configuration of the DateTime library source failed" \
-              "tried to run the cmake command as:" \
-              "cmake -S ${src_dir} -B ${bld_dir} ${cmake_flags}"
-  fi
-  ##########
-
-
-  ##########
-  ### Run cmake to build the application
-  ##########
-  eval "cmake --build ${bld_dir}"
-  err=$?
-
-  if [ ${err:-0} -ne 0 ]; then
-    procError "the compilation of the DateTime library failed" \
-              "tried to run the cmake command as:" \
-              "cmake --build ${bld_dir}"
-  fi
-  ##########
-
-
-  ##########
-  ### Install the application files
-  ##########
-  lib_dir=${inst_dir}/lib
-  inc_dir=${inst_dir}/include
-
-  for i in ${lib_dir} ${inc_dir}
-  do
-    if [ ! -d "${i}" ]; then
-      mkdir -p ${i}
-      err=$?
-
-      if [ ${err:-0} -ne 0 ]; then
-        procError "could not create the install directory" \
-                  "  instDIR = ${i}"
+  ######################
+  ### BEG :: thirdparty_open build
+  ### This part of the code is executed only if the user requested
+  ### to build the library from the thirdparty_open directory.
+  ### This precedes any environment settings.
+  ######################
+  if [ ${tpDateTimeRequested:-0} -ge 1 ]; then
+    ### Get the location of the third party directory
+      ### Get the location of the third party directory
+      checkDIR -rx "${1}"
+      if [ $? -eq 0 ]; then
+        root_dir="${1}"
+      else
+        root_dir="${APP_DIR:+${APP_DIR}/}thirdparty_open"
       fi
+
+    ### Get the location of the install directory
+    inst_dir="${APP_DIR:+${APP_DIR}/}THIRDPARTY_INSTALL"
+
+
+    ##########
+    ### Try to get all the required directories to compile the application 
+    ##########
+    src_dir="$( find ${root_dir} -maxdepth 1 -type d -iname "*DATETIME*" | head -n 1 )"
+    if [ -z "${src_dir}" ] || [ ! -d "${src_dir}" ]; then
+      procError "the source directory for the DateTime library is not a valid directory:" \
+                "  srcDIR = ${src_dir:-NOTFOUND}" \
+                "searched in rootDIR = ${root_dir:-NOTFOUND}"
     fi
-  done
 
-  install -m 0644 ${bld_dir}/lib/*.a ${lib_dir}/
-  err=$?
+    bld_dir=${src_dir}/build
+    lib_dir=${src_dir}/lib
+    inc_dir=${src_dir}/include
 
-  install -m 0644 ${bld_dir}/include/* ${inc_dir}/
-  err=$?
-  ##########
-
-  ##########
-  ### Remove/Clean the compiled programs and libraries
-  ##########
-  lib_dir=${src_dir}/lib
-  inc_dir=${src_dir}/include
-
-  if [ ${err:-0} -eq 0 ]; then
+    ### Remove/Clean the previously compiled programs and libraries
     for i in ${bld_dir} ${lib_dir} ${inc_dir}
     do
-      if [ -d "${i}" ]; then
-        rm -rf ${i}
-        err=$?
-      fi
+      deleteDIR "${i}"
     done
+    ##########
+
+
+    ### Set the compilation flags for cmake
+    cmake_flags="-DCMAKE_BUILD_TYPE=Release"
+    [ -n "${VERBOSE:+1}" ] && cmake_flags+=" -DCMAKE_VERBOSE_MAKEFILE=TRUE"
+
+    cmake_flags+=" -DCMAKE_Fortran_COMPILER=${F90:-${FC}}"
+    [ -n "${FFLAGS:+1}" ] && cmake_flags+=" -DCMAKE_Fortran_FLAGS=${FFLAGS}"
+
+
+    ##########
+    ### Run cmake to configure the application
+    ##########
+    eval "cmake -S ${src_dir} -B ${bld_dir} ${cmake_flags}"
+    err=$?
+
+    if [ ${err:-0} -ne 0 ]; then
+      procError "the configuration of the DateTime library source failed" \
+                "tried to run the cmake command as:" \
+                "cmake -S ${src_dir} -B ${bld_dir} ${cmake_flags}"
+    fi
+    ##########
+
+
+    ##########
+    ### Run cmake to build the application
+    ##########
+    eval "cmake --build ${bld_dir}"
+    err=$?
+
+    if [ ${err:-0} -ne 0 ]; then
+      procError "the compilation of the DateTime library failed" \
+                "tried to run the cmake command as:" \
+                "cmake --build ${bld_dir}"
+    fi
+    ##########
+
+
+    ##########
+    ### Install the application files
+    ##########
+    lib_dir=${inst_dir}/lib
+    inc_dir=${inst_dir}/include
+
+    for i in ${lib_dir} ${inc_dir}
+    do
+      makeDIR "${i}"
+    done
+
+    install -m 0644 ${bld_dir}/lib/*.a ${lib_dir}/
+    err=$?
+
+    install -m 0644 ${bld_dir}/include/* ${inc_dir}/
+    err=$?
+    ##########
+
+    ##########
+    ### Remove/Clean the compiled programs and libraries
+    ##########
+    lib_dir=${src_dir}/lib
+    inc_dir=${src_dir}/include
+
+    if [ ${err:-0} -eq 0 ]; then
+      for i in ${bld_dir} ${lib_dir} ${inc_dir}
+      do
+        deleteDIR "${i}"
+      done
+    fi
+    ##########
+
+
+    export DATETIMEHOME="${inst_dir}"
+    export DATETIME=enable
+    procWarn "Setting the following variables:" \
+             "   DATETIMEHOME = ${DATETIMEHOME}" \
+             "   DATETIME     = ${DATETIME}"
+    
+
+    return ${err}
   fi
-  ##########
+  ######################
+  ### END :: thirdparty_open build
+  ######################
 
-  DATETIMEHOME="${inst_dir}"
 
-  return ${err}
+  ######################
+  ### BEG :: Use pre-compiled libraries
+  ######################
+  if [ ${tpDateTimeRequested:-0} -le 0 ]; then
+    # Get the location of the pre-compiled third party libraries for DATETIME.
+    if [ -n "${DATETIMEHOME}" ]; then
+      checkDIR -rx "${DATETIMEHOME}"
+      if [ $? -eq 0 ]; then
+        tmp_inc="$( find -L ${DATETIMEHOME}/include -maxdepth 1 -type f -name "datetime_module.mod" | head -1 )"
+        tmp_lib="$( find -L ${DATETIMEHOME}/lib -maxdepth 1 -type f -name "libdatetime.*" | head -1 )"
+        if [ -n "${tmp_inc:+1}" ] && [ -n "${tmp_lib:+1}" ]; then
+          export DATETIMEHOME=${DATETIMEHOME}
+          export DATETIME=enable
+          procWarn "Setting the following variables:" \
+                   "   DATETIMEHOME = ${DATETIMEHOME}" \
+                   "   DATETIME     = ${DATETIME}"
+          return 0
+        else
+          procError "Could not locate libdatetime in DATETIMEHOME = ${DATETIMEHOME}." \
+                    "Is DATETIMEHOME environment variable set properly?"
+        fi
+      else
+        procError "DATETIMEHOME = ${DATETIMEHOME} is not a valid directory." \
+                  "Is DATETIMEHOME environment variable set properly?"
+      fi
+    fi
+  fi
+  ######################
+  ### END :: Use pre-compiled libraries
+  ######################
 }
 
 ###========================================
@@ -888,170 +945,272 @@ compileDateTime() {
 ### compileMetis: Uses environment variables to compile the application.
 ###========================================
 compileMetis() {
-  local root_dir src_dir gklib_dir metis_dir cmake_flags
+  local root_dir src_dir gklib_dir metis_dir make_flags
   local loc_dir lib_dir inc_dir inst_dir
-  local i
-  local err=0
-
-  ### Get the location of the third party directory
-  if [ -d "${1}" ]; then
-    root_dir="${1}"
-  else
-    root_dir="${APP_DIR:+${APP_DIR}/}thirdparty_open"
-  fi
-
-  ### Get the location of the install directory
-  inst_dir="${APP_DIR:+${APP_DIR}/}THIRDPARTY_INSTALL"
+  local i bits64 tmp_inc tmp_lib
+  local err bits64 tpMetisRequested
 
 
-  ##########
-  ### Try to get all the required directories to compile the application 
-  ##########
-  src_dir="$( find ${root_dir} -maxdepth 1 -type d -iname "*ParMETIS*" | head -n 1 )"
-  if [ -z "${src_dir}" ] || [ ! -d "${src_dir}" ]; then
-    procError "the source directory for the ParMetis/Metis library is not a valid directory:" \
-              "  srcDIR = ${src_dir:-NOTFOUND}" \
-              "searched in rootDIR = ${root_dir:-NOTFOUND}"
-  fi
-
-  ### Remove/Clean the previously compiled programs and libraries
-  find ${src_dir} -type d -name build -exec rm -rf {} \; >/dev/null 2>&1
-  ##########
-
-  loc_dir=${src_dir}/del
-  makeDIR ${loc_dir}
-
-  ### Set the compilation flags for cmake
-#  cmake_flags="-DCMAKE_BUILD_TYPE=Release"
-#  [ -n "${VERBOSE:+1}" ] && cmake_flags+=" -DCMAKE_VERBOSE_MAKEFILE=TRUE"
-
-#  cmake_flags+=" -DCMAKE_C_COMPILER=${PCC:-mpicc} CMAKE_CXX_COMPILER=${PCXX:-mpicxx}"
-#  [ -n "${FFLAGS:+1}" ] && cmake_flags+=" -DCMAKE_C_FLAGS=${CFLAGS}"
+  err=0
+  bits64=1
+  tpMetisRequested=0
 
 
-  ##########
-  ### Run make/cmake to configure the application
-  ##########
-  ### (1) configure GKlib if the directory exists
-  gklib_dir="$( find ${src_dir} -type d -iname "GKlib" | head -n 1 )"
-
-  if [ -d "${gklib_dir}" ]; then
-    pushd ${gklib_dir} >/dev/null 2>&1
-      eval "make config CC=${CC:-gcc} CXX=${CXX:-g++} CFLAGS=${CFLAGS} prefix=${loc_dir}"
-      err=$?
-
-      if [ ${err:-0} -ne 0 ]; then
-        procError "the configuration of the GKlib library source failed" \
-                  "tried to run the make command as:" \
-                  "make config CC=${CC:-gcc} CXX=${CXX:-g++} CFLAGS=${CFLAGS} prefix=${loc_dir}"
-      fi
-
-      make install
-      err=$?
-
-      if [ ${err:-0} -ne 0 ]; then
-        procError "the compilation of the GKlib library failed" \
-                  "tried to run the make command as:" \
-                  "make install"
-      fi
-    popd >/dev/null 2>&1
-  else
-    procError "the directory of the GKlib source could not be located" \
-              "inside the ${src_dir} folder."
-  fi
-
-  ### (2) configure metis if the directory exists
-  metis_dir="$( find ${src_dir} -type d -iname "metis" | head -n 1 )"
-
-  if [ -d "${metis_dir}" ]; then
-    pushd ${metis_dir} >/dev/null 2>&1
-      eval "make config CC=${CC:-gcc} CXX=${CXX:-g++} CFLAGS=${CFLAGS} i64=1 r64=1 gklib_path=${gklib_dir} prefix=${loc_dir}"
-      err=$?
-
-      if [ ${err:-0} -ne 0 ]; then
-        procError "the configuration of the METIS library source failed" \
-                  "tried to run the make command as:" \
-                  "make config CC=${CC:-gcc} CXX=${CXX:-g++} CFLAGS=${CFLAGS} i64=1 r64=1 gklib_path=${gklib_dir} prefix=${loc_dir}"
-      fi
-
-      make install
-      err=$?
-
-      if [ ${err:-0} -ne 0 ]; then
-        procError "the compilation of the METIS library failed" \
-                  "tried to run the make command as:" \
-                  "make install"
-      fi
-    popd >/dev/null 2>&1
-  else
-    procError "the directory of the METIS source could not be located" \
-              "inside the ${src_dir} folder."
-  fi
-
-  ### (3) configure parmetis if the directory exists
-  this_dir="${src_dir}"
-
-  pushd ${this_dir} >/dev/null 2>&1
-    eval "make config CC=${PCC:-mpicc} CXX=${PCXX:-mpicxx} CFLAGS=${CFLAGS} i64=1 r64=1 gklib_path=${gklib_dir} metis_path=${loc_dir} prefix=${loc_dir}"
-    err=$?
-
-    if [ ${err:-0} -ne 0 ]; then
-      procError "the configuration of the ParMETIS library source failed" \
-                "tried to run the make command as:" \
-                "make config CC=${PCC:-mpicc} CXX=${PCXX:-mpicxx} CFLAGS=${CFLAGS} i64=1 r64=1 gklib_path=${gklib_dir} metis_path=${loc_dir} prefix=${loc_dir}"
-    fi
-
-    make
-    err=$?
-
-    if [ ${err:-0} -ne 0 ]; then
-      procError "the compilation of the ParMETIS library failed" \
-                "tried to run the make command as:" \
-                "make install"
-    fi
-  popd >/dev/null 2>&1
-  ##########
-
-
-  ##########
-  ### Install the application files
-  ##########
-  lib_dir=${inst_dir}/lib
-  inc_dir=${inst_dir}/include
-
-  for i in ${lib_dir} ${inc_dir}
+  # First check if the user explicitly requested to build PerMetis
+  # from the thirdparty_open directory. It is the user's responsibility
+  # to download ParMetis into the thirdparty_open directory
+  # (CoastalApp does not ship with ParMetis).
+  for iPart in ${THIRDPARTY}
   do
-    if [ ! -d "${i}" ]; then
-      mkdir -p ${i}
-      err=$?
-
-      if [ ${err:-0} -ne 0 ]; then
-        procError "could not create the install directory" \
-                  "  instDIR = ${i}"
-      fi
-    fi
+    case "$( toUPPER ${iPart} )" in
+      METIS|PARMETIS)
+        tpMetisRequested=1
+        break
+        ;;
+      *)
+        ;; #Do Nothing
+    esac
   done
 
-  install -m 0644 ${loc_dir}/lib/* ${lib_dir}/
-  err=$?
 
-  install -m 0644 ${loc_dir}/include/* ${inc_dir}/
-  err=$?
-  ##########
+  ######################
+  ### BEG :: thirdparty_open build
+  ### This part of the code is executed only if the user requested
+  ### to build the library from the thirdparty_open directory.
+  ### This precedes the environment settings.
+  ######################
+  if [ ${tpMetisRequested:-0} -ge 1 ]; then
+    ### Get the location of the third party directory
+    checkDIR -rx "${1}"
+    if [ $? -eq 0 ]; then
+      root_dir="${1}"
+    else
+      root_dir="${APP_DIR:+${APP_DIR}/}thirdparty_open"
+    fi
+
+    ### Get the location of the install directory
+    inst_dir="${APP_DIR:+${APP_DIR}/}THIRDPARTY_INSTALL"
 
 
-  ##########
-  ### Remove/Clean the compiled programs and libraries
-  ##########
-  rm -rf ${loc_dir}
+    ##########
+    ### Try to get all the required directories to compile the application 
+    ##########
+    src_dir="$( find ${root_dir} -maxdepth 1 -type d -iname "*ParMETIS*" | head -n 1 )"
+    if [ -z "${src_dir}" ] || [ ! -d "${src_dir}" ]; then
+      procError "the source directory for the ParMetis/Metis library is not a valid directory:" \
+                "  srcDIR = ${src_dir:-NOTFOUND}" \
+                "searched in rootDIR = ${root_dir:-NOTFOUND}"
+    fi
 
-  find ${src_dir} -type d -name build -exec rm -rf {} \; >/dev/null 2>&1
-  ##########
+    ### Remove/Clean the previously compiled programs and libraries
+    find ${src_dir} -type d -name build -exec rm -rf {} \; >/dev/null 2>&1
+    ##########
 
-  METISHOME="${inst_dir}"
-  PARMETISHOME="${inst_dir}"
+    loc_dir=${src_dir}/del
+    makeDIR ${loc_dir}
 
-  return ${err}
+    ##########
+    ### Run make/cmake to configure the application
+    ##########
+    ### (1) configure GKlib if the directory exists
+    make_flags="CC=${CC:-gcc} CXX=${CXX:-g++} CFLAGS=${CFLAGS}"
+    gklib_dir="$( find ${src_dir} -type d -iname "GKlib" | head -n 1 )"
+
+    if [ -d "${gklib_dir}" ]; then
+      pushd ${gklib_dir} >/dev/null 2>&1
+        eval "make config ${make_flags} prefix=${loc_dir}"
+        err=$?
+
+        if [ ${err:-0} -ne 0 ]; then
+          procError "the configuration of the GKlib library source failed" \
+                    "tried to run the make command as:" \
+                    "make config ${make_flags} prefix=${loc_dir}"
+        fi
+
+        make install
+        err=$?
+
+        if [ ${err:-0} -ne 0 ]; then
+          procError "the compilation of the GKlib library failed" \
+                    "tried to run the make command as:" \
+                    "make install"
+        fi
+      popd >/dev/null 2>&1
+    else
+      procError "the directory of the GKlib source could not be located" \
+                "inside the ${src_dir} folder."
+    fi
+
+    ### (2) configure metis if the directory exists
+    if [ "${bits64:-0}" -ge 1 ]; then
+      make_flags="CC=${CC:-gcc} CXX=${CXX:-g++} CFLAGS=${CFLAGS} i64=1 r64=1"
+    else
+      make_flags="CC=${CC:-gcc} CXX=${CXX:-g++} CFLAGS=${CFLAGS}"
+    fi
+    metis_dir="$( find ${src_dir} -type d -iname "metis" | head -n 1 )"
+
+    if [ -d "${metis_dir}" ]; then
+      pushd ${metis_dir} >/dev/null 2>&1
+        if [ "${bits64:-0}" -ge 1 ]; then
+          sed -i -e 's@^#define[[:space:]]*IDXTYPEWIDTH[[:space:]]*32@#define IDXTYPEWIDTH 64@' include/metis.h
+          sed -i -e 's@^#define[[:space:]]*REALTYPEWIDTH[[:space:]]*32@#define REALTYPEWIDTH 64@' include/metis.h
+        else
+          sed -i -e 's@^#define[[:space:]]*IDXTYPEWIDTH[[:space:]]*64@#define IDXTYPEWIDTH 32@' include/metis.h
+          sed -i -e 's@^#define[[:space:]]*REALTYPEWIDTH[[:space:]]*64@#define REALTYPEWIDTH 32@' include/metis.h
+        fi
+      
+        eval "make config ${make_flags} gklib_path=${gklib_dir} prefix=${loc_dir}"
+        err=$?
+
+        if [ ${err:-0} -ne 0 ]; then
+          procError "the configuration of the METIS library source failed" \
+                    "tried to run the make command as:" \
+                    "make config ${make_flags} gklib_path=${gklib_dir} prefix=${loc_dir}"
+        fi
+
+        make install
+        err=$?
+
+        if [ ${err:-0} -ne 0 ]; then
+          procError "the compilation of the METIS library failed" \
+                    "tried to run the make command as:" \
+                    "make install"
+        fi
+      popd >/dev/null 2>&1
+    else
+      procError "the directory of the METIS source could not be located" \
+                "inside the ${src_dir} folder."
+    fi
+
+    ### (3) configure parmetis if the directory exists
+    make_flags="CC=${PCC:-mpicc} CXX=${PCXX:-mpicxx} CFLAGS=${CFLAGS}"
+    # This is a workaround because the metis/include/metis.h does not defile
+    # IDXTYPEWIDTH and REALTYPEWIDTH it is defined thought after processing metis/include/metis.h
+    # and installing the metis.h file in the installation include directory.
+    if [ "${bits64:-0}" -ge 1 ]; then
+      make_flags+=" CONFIG_FLAGS1=-DCMAKE_C_FLAGS='\"-DIDXTYPEWIDTH=64 -DREALTYPEWIDTH=64\"'"
+    else
+      make_flags+=" CONFIG_FLAGS1=-DCMAKE_C_FLAGS='\"-DIDXTYPEWIDTH=32 -DREALTYPEWIDTH=32\"'"
+    fi
+    this_dir="${src_dir}"
+
+    pushd ${this_dir} >/dev/null 2>&1
+      sed -i -e 's@\(CONFIG_FLAGS[[:space:]]*=[[:space:]]*-DCMAKE_VERBOSE_MAKEFILE=1[[:space:]]*\)$@\1 \$(CONFIG_FLAGS1)@' Makefile
+      eval "make config "${make_flags}" gklib_path=${gklib_dir} metis_path=${metis_dir} prefix=${loc_dir}"
+      err=$?
+
+      if [ ${err:-0} -ne 0 ]; then
+        procError "the configuration of the ParMETIS library source failed" \
+                  "tried to run the make command as:" \
+                  "make config ${make_flags} gklib_path=${gklib_dir} metis_path=${metis_dir} prefix=${loc_dir}"
+      fi
+
+      make install
+      err=$?
+
+      if [ ${err:-0} -ne 0 ]; then
+        procError "the compilation of the ParMETIS library failed" \
+                  "tried to run the make command as:" \
+                  "make install"
+      fi
+    popd >/dev/null 2>&1
+    ##########
+
+
+    ##########
+    ### Install the application files
+    ##########
+    lib_dir=${inst_dir}/lib
+    inc_dir=${inst_dir}/include
+
+    for i in ${lib_dir} ${inc_dir}
+    do
+      if [ ! -d "${i}" ]; then
+        mkdir -p ${i}
+        err=$?
+
+        if [ ${err:-0} -ne 0 ]; then
+          procError "could not create the install directory" \
+                    "  instDIR = ${i}"
+        fi
+      fi
+    done
+
+    install -m 0644 ${loc_dir}/lib/* ${lib_dir}/
+    err=$?
+
+    install -m 0644 ${loc_dir}/include/* ${inc_dir}/
+    err=$?
+    ##########
+
+
+    ##########
+    ### Remove/Clean the compiled programs and libraries
+    ##########
+    if [ ${err:-0} -eq 0 ]; then
+      deleteDIR "${loc_dir}"
+
+      find ${src_dir} -type d -name build -exec rm -rf {} \; >/dev/null 2>&1
+    fi
+    ##########
+
+    unset PARMETISHOME METISHOME PARMETIS_HOME METIS_HOME
+    unset PARMETISROOT METISROOT PARMETIS_ROOT METIS_ROOT
+    unset PARMETISPATH METISPATH PARMETIS_PATH METIS_PATH
+    unset PARMETISDIR METISDIR PARMETIS_DIR METIS_DIR
+
+    export PARMETISHOME="${inst_dir}"
+    export METISHOME="${inst_dir}"
+    export METIS=${PARMETISHOME}
+    export METIS_PATH=${PARMETISHOME}
+    procWarn "Setting the following variables:" \
+             "   PARMETISHOME = ${PARMETISHOME}" \
+             "   METISHOME    = ${METISHOME}" \
+             "   METIS        = ${METIS}" \
+             "   METIS_PATH   = ${METIS_PATH}"
+
+
+    return ${err}
+  fi
+  ######################
+  ### END :: thirdparty_open build
+  ######################
+
+
+  ######################
+  ### BEG :: Use pre-compiled libraries
+  ######################
+  if [ ${tpMetisRequested:-0} -le 0 ]; then
+    # Get the location of the pre-compiled third party libraries for PARMETIS.
+    if [ -n "${PARMETISHOME}" ]; then
+      checkDIR -rx "${PARMETISHOME}"
+      if [ $? -eq 0 ]; then
+        tmp_inc="$( find -L ${PARMETISHOME}/include -maxdepth 1 -type f -name "parmetis.h" | head -1 )"
+        tmp_lib="$( find -L ${PARMETISHOME}/lib -maxdepth 1 -type f -name "libparmetis.*" | head -1 )"
+        if [ -n "${tmp_inc:+1}" ] && [ -n "${tmp_lib:+1}" ]; then
+          export PARMETISHOME=${PARMETISHOME}
+          export METISHOME=${PARMETISHOME}
+          export METIS=${PARMETISHOME}
+          export METIS_PATH=${PARMETISHOME}
+          procWarn "Setting the following variables:" \
+                   "   PARMETISHOME = ${PARMETISHOME}" \
+                   "   METISHOME    = ${METISHOME}" \
+                   "   METIS        = ${METIS}" \
+                   "   METIS_PATH   = ${METIS_PATH}"
+          return 0
+        else
+          procError "Could not locate libparmetis in PARMETISHOME = ${PARMETISHOME}." \
+                    "Is PARMETISHOME environment variable set properly?"
+        fi
+      else
+        procError "PARMETISHOME = ${PARMETISHOME} is not a valid directory." \
+                  "Is PARMETISHOME environment variable set properly?"
+      fi
+    fi
+  fi
+  ######################
+  ### END :: Use pre-compiled libraries
+  ######################
 }
 
 ###========================================


### PR DESCRIPTION
The build scripts have been updated to allow configuring the third party libraries and programs:
a) using environment variables that point to the location of the pre-compiled (externally or internally to CoastalApp)
    libraries and programs (CoastalApp exports relevant environment variables that are passed to the modeling components)
b) compiling the libraries within CoastalApp per user's request using the --thirdparty option to the build script.

Currently only DateTime and ParMetis are supported. CoastalApp does not ship with ParMetis and it is
the user's responsibility to download the library (the script scripts/download_parmetis.sh can be used for that purpose).