### PR TITLE
Update envmodules_intel.hera

### DIFF
--- a/modulefiles/envmodules_intel.hera
+++ b/modulefiles/envmodules_intel.hera
@@ -29,7 +29,7 @@ module purge
 
 module use /scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.1/envs/unified-env-rocky8/install/modulefiles/Core
 
-module load stack-intel/2021.5.1
+module load stack-intel/2021.5.0
 module load stack-intel-oneapi-mpi/2021.5.1
 
 module load cmake/3.23.1


### PR DESCRIPTION
Fixing typo in envmodules_intel.hera: 

There's no stack-intel/2021.5.1 module in this "module use" location. Edited to 2021.5.0 to prevent exiting with error